### PR TITLE
Add Live RST Playground

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Documentation & Guides
 * `RST & Sphinx Cheatsheet
   <https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html>`_ -
   Needs review to authenticate awesomeness.
+* `Live RST Playground
+  <https://waldyrious.github.io/rst-playground>`_ - Render reStructuredText content directly in the browser
 
 To reST or not to reST?
 =======================


### PR DESCRIPTION
Since http://rst.ninjs.org has been down for a while, and https://livesphinx.herokuapp.com stopped working with [Heroku's removal of the free tier](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq), I decided to try setting up a similar playground that does not depend on a server-side renderer. The result is now live at https://waldyrious.github.io/rst-playground, and the source code can be found at https://github.com/waldyrious/rst-playground.

It is pretty basic but seems to work well. I thought it would be worth linking from this list.